### PR TITLE
Fixed layers parameter query string building

### DIFF
--- a/src/OrsGeocode.js
+++ b/src/OrsGeocode.js
@@ -84,8 +84,13 @@ OrsGeocode.prototype.lookupParameter = {
   },
   layers: function(key, val) {
     let urlParams = '&layers='
-    for (source in val) {
-      urlParams += source + ','
+    let counter = 0
+    for (key in val) {
+      if (counter > 0) {
+        urlParams += ','
+      }
+      urlParams += val[key]
+      counter++
     }
     urlParams
     return urlParams


### PR DESCRIPTION
Fixed layers parameter query string so that it uses the array value instead of the array key and  do not add the comma after the last value