### PR TITLE
Fixed layer option from 'county' to 'country'

### DIFF
--- a/src/schemas/geocode/OrsReverseGeocodeSchema.js
+++ b/src/schemas/geocode/OrsReverseGeocodeSchema.js
@@ -38,7 +38,7 @@ const schema = Joi.object()
           'macrocounty',
           'region',
           'macroregion',
-          'county',
+          'country',
           'coarse'
         )
       )


### PR DESCRIPTION
The layer option county was specified twice and it was missing country.