### PR TITLE
Return the full error object in OrsDirections

### DIFF
--- a/src/OrsDirections.js
+++ b/src/OrsDirections.js
@@ -100,8 +100,7 @@ class OrsDirections {
           .end(function(err, res) {
             //console.log(res.body, res.headers, res.status)
             if (err || !res.ok) {
-              //reject(ghUtil.extractError(res, url));
-              reject(new Error(err))
+              reject(err)
             } else if (res) {
               resolve(res.body)
             }


### PR DESCRIPTION
Return the full error object in OrsDirections when the request fails.

As the Error constructor expects a string https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error somehow the Error class is getting the first property that is a string and using it in the constructor. Then the error returned is alsways a string and the consumer doesn't have access to the error details, like the error code.