### PR TITLE
fix on openrouteservice url at matrixschema

### DIFF
--- a/src/schemas/OrsMatrixSchema.js
+++ b/src/schemas/OrsMatrixSchema.js
@@ -62,7 +62,7 @@ const schema = Joi.object()
       .default('v2')
       .description('Determines the API version to be used.'),
     host: Joi.string()
-      .default('https://api.openrouteservice.org/matrix')
+      .default('https://api.openrouteservice.org')
       .description('Determines the API url.'),
     mime_type: Joi.string()
       .valid(['application/json'])


### PR DESCRIPTION
Change from https://api.openrouteservice.org/matrix to https://api.openrouteservice.org.