### PR TITLE
fix: gpx response not returned correctly

### DIFF
--- a/src/OrsBase.js
+++ b/src/OrsBase.js
@@ -77,7 +77,7 @@ class OrsBase {
         throw error
       }
 
-      return await orsResponse.json() || orsResponse.text()
+      return this.argsCache?.format === 'gpx' ? await orsResponse.text() : await orsResponse.json()
     } finally {
       clearTimeout(timeout)
     }


### PR DESCRIPTION
the text response from the gpx endpoint was also retrieved through the .json function of the Response object which threw an error as it was not possible to parse the gpx to json.

For gpx it now uses the .text function instead and just returns the gpx result as a string.